### PR TITLE
Fix missing toolbar icons by renaming namespaces to match Assembly name

### DIFF
--- a/Demos/OpenSource/FastReport.OpenSource.Web.MVC/Controllers/HomeController.cs
+++ b/Demos/OpenSource/FastReport.OpenSource.Web.MVC/Controllers/HomeController.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using FastReport.Web;
+using FastReport.OpenSource.Web;
 using FastReport.OpenSource.Web.MVC.Models;
 using Microsoft.AspNetCore.Mvc;
 using System.IO;

--- a/FastReport.Core.Web/Application/Extensions.cs
+++ b/FastReport.Core.Web/Application/Extensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     public static class Extensions
     {

--- a/FastReport.Core.Web/Application/FastReportBuilderExtensions.cs
+++ b/FastReport.Core.Web/Application/FastReportBuilderExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FastReport.Web;
+using FastReport.OpenSource.Web;
 using Microsoft.AspNetCore.Routing;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;

--- a/FastReport.Core.Web/Application/FastReportGlobal.cs
+++ b/FastReport.Core.Web/Application/FastReportGlobal.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using System;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     class FastReportGlobal
     {

--- a/FastReport.Core.Web/Application/FastReportMiddleware.cs
+++ b/FastReport.Core.Web/Application/FastReportMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using FastReport.Web.Controllers;
+﻿using FastReport.OpenSource.Web.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Routing;
 using System;
 using System.Threading.Tasks;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     class FastReportMiddleware
     {

--- a/FastReport.Core.Web/Application/FastReportOptions.cs
+++ b/FastReport.Core.Web/Application/FastReportOptions.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     public class FastReportOptions
     {

--- a/FastReport.Core.Web/Application/ReportTab.cs
+++ b/FastReport.Core.Web/Application/ReportTab.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     public class ReportTabCollection : Collection<ReportTab>
     {

--- a/FastReport.Core.Web/Application/Resources.cs
+++ b/FastReport.Core.Web/Application/Resources.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     class Resources
     {

--- a/FastReport.Core.Web/Application/WebReport.Exports.cs
+++ b/FastReport.Core.Web/Application/WebReport.Exports.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Application/WebReport.cs
+++ b/FastReport.Core.Web/Application/WebReport.cs
@@ -5,10 +5,10 @@ using System.Text;
 using Microsoft.AspNetCore.Html;
 using System.Threading.Tasks;
 using System.Linq;
-using FastReport.Web.Controllers;
-using FastReport.Web.Application;
+using FastReport.OpenSource.Web.Controllers;
+using FastReport.OpenSource.Web.Application;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     public enum WebReportMode
     {

--- a/FastReport.Core.Web/Application/WebReportCache.cs
+++ b/FastReport.Core.Web/Application/WebReportCache.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     class WebReportCache
     {

--- a/FastReport.Core.Web/Application/WebReportDesigner.cs
+++ b/FastReport.Core.Web/Application/WebReportDesigner.cs
@@ -12,7 +12,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Application/WebReportHtml.cs
+++ b/FastReport.Core.Web/Application/WebReportHtml.cs
@@ -1,7 +1,7 @@
 ﻿using FastReport.Export.Html;
 using FastReport.Preview;
 using FastReport.Table;
-using FastReport.Web.Controllers;
+using FastReport.OpenSource.Web.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -12,7 +12,7 @@ using System.Text;
 using FastReport.Export.Pdf;
 #endif
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     public partial class WebReport
     {

--- a/FastReport.Core.Web/Application/WebResources.cs
+++ b/FastReport.Core.Web/Application/WebResources.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace FastReport.Web.Application
+namespace FastReport.OpenSource.Web.Application
 {
     internal class WebRes
     {

--- a/FastReport.Core.Web/Application/WebUtils.cs
+++ b/FastReport.Core.Web/Application/WebUtils.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using FastReport.Export;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     static class WebUtils
     {

--- a/FastReport.Core.Web/Controllers/BaseController.cs
+++ b/FastReport.Core.Web/Controllers/BaseController.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace FastReport.Web.Controllers
+namespace FastReport.OpenSource.Web.Controllers
 {
     abstract class BaseController
     {

--- a/FastReport.Core.Web/Controllers/DesignerController.cs
+++ b/FastReport.Core.Web/Controllers/DesignerController.cs
@@ -10,7 +10,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Encodings.Web;
 
-namespace FastReport.Web.Controllers
+namespace FastReport.OpenSource.Web.Controllers
 {
     class DesignerController : BaseController
     {

--- a/FastReport.Core.Web/Controllers/ReportController.cs
+++ b/FastReport.Core.Web/Controllers/ReportController.cs
@@ -22,7 +22,7 @@ using FastReport.Export.XAML;
 using FastReport.Export.Xml;
 #endif
 
-namespace FastReport.Web.Controllers
+namespace FastReport.OpenSource.Web.Controllers
 {
     class ReportController : BaseController
     {

--- a/FastReport.Core.Web/Controllers/ResourceController.cs
+++ b/FastReport.Core.Web/Controllers/ResourceController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Http;
 
-namespace FastReport.Web.Controllers
+namespace FastReport.OpenSource.Web.Controllers
 {
     class ResourceController : BaseController
     {

--- a/FastReport.Core.Web/Templates/body.cs
+++ b/FastReport.Core.Web/Templates/body.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/main.cs
+++ b/FastReport.Core.Web/Templates/main.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/outline.cs
+++ b/FastReport.Core.Web/Templates/outline.cs
@@ -5,7 +5,7 @@ using System.Net;
 using System.Text;
 using System.Web;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/script.cs
+++ b/FastReport.Core.Web/Templates/script.cs
@@ -1,4 +1,4 @@
-﻿namespace FastReport.Web
+﻿namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/style.cs
+++ b/FastReport.Core.Web/Templates/style.cs
@@ -1,4 +1,4 @@
-﻿namespace FastReport.Web
+﻿namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/tabs.cs
+++ b/FastReport.Core.Web/Templates/tabs.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {

--- a/FastReport.Core.Web/Templates/toolbar.cs
+++ b/FastReport.Core.Web/Templates/toolbar.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace FastReport.Web
+namespace FastReport.OpenSource.Web
 {
     partial class WebReport
     {


### PR DESCRIPTION
Fix for issue https://github.com/FastReports/FastReport/issues/145