### PR TITLE
Enable TLS 1.2 in ImageHelper

### DIFF
--- a/FastReport.Base/Utils/ImageHelper.cs
+++ b/FastReport.Base/Utils/ImageHelper.cs
@@ -164,6 +164,8 @@ namespace FastReport.Utils
         {
             if (!String.IsNullOrEmpty(url))
             {
+                //Enable TLS1.2, 1.1. and 1.0;
+                System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)(0xc0 | 0x300 | 0xc00); // System.Net.SecurityProtocolType.Tls | System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls12;
                 using (WebClient web = new WebClient())
                 {
                     return web.DownloadData(url);


### PR DESCRIPTION
#254 is fixed by this pull request. Code enables Both TLS version 1.0, 1.1. and 1.2.