### PR TITLE
Fix for Print from Browser when exporting to HTML

### DIFF
--- a/Demos/OpenSource/FastReport.OpenSource.MVC/FastReport.OpenSource.MVC.csproj
+++ b/Demos/OpenSource/FastReport.OpenSource.MVC/FastReport.OpenSource.MVC.csproj
@@ -23,6 +23,9 @@
   <ItemGroup>
     <PackageReference Include="FastReport.OpenSource" Version="$(FROSVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\FastReport.OpenSource\FastReport.OpenSource.csproj" />
+  </ItemGroup>
 
 
   

--- a/Demos/OpenSource/FastReport.OpenSource.Web.MVC/FastReport.OpenSource.Web.MVC.csproj
+++ b/Demos/OpenSource/FastReport.OpenSource.Web.MVC/FastReport.OpenSource.Web.MVC.csproj
@@ -16,5 +16,8 @@
   <ItemGroup>
     <PackageReference Include="FastReport.OpenSource.Web" Version="$(FROSWebVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\FastReport.Core.Web\FastReport.OpenSource.Web.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Extras/OpenSource/FastReport.OpenSource.Export.PdfSimple/FastReport.OpenSource.Export.PdfSimple/FastReport.OpenSource.Export.PdfSimple.csproj
+++ b/Extras/OpenSource/FastReport.OpenSource.Export.PdfSimple/FastReport.OpenSource.Export.PdfSimple/FastReport.OpenSource.Export.PdfSimple.csproj
@@ -31,5 +31,8 @@
   <ItemGroup>
     <PackageReference Include="FastReport.OpenSource" Version="$(FROSVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\FastReport.OpenSource\FastReport.OpenSource.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/FastReport.Base/Export/Html/HTMLExportLayers.cs
+++ b/FastReport.Base/Export/Html/HTMLExportLayers.cs
@@ -773,6 +773,9 @@ namespace FastReport.Export.Html
 
                 htmlPage.Append(HTMLGetAncor((d.PageNumber).ToString()));
 
+                if (doPageBreak && d.PageNumber > 1)
+                    htmlPage.Append("<div style=\"break-after:page\"></div>").ToString();
+
                 pageStyleName = "frpage" + currentPage;
                 htmlPage.Append("<div ").Append(doPageBreak ? "class=\"" + pageStyleName + "\"" : String.Empty)
                     .Append(" style=\"position:relative;")


### PR DESCRIPTION
Change to include page break when exporting to HTML as suggested in comment: https://github.com/FastReports/FastReport/issues/174#issuecomment-801823256. 

Related reported issues:
https://github.com/FastReports/FastReport/issues/174
https://github.com/FastReports/FastReport/issues/220