### PR TITLE
add !calculated in check columns removing

### DIFF
--- a/FastReport.Base/Data/BusinessObjectConverter.cs
+++ b/FastReport.Base/Data/BusinessObjectConverter.cs
@@ -332,7 +332,7 @@ namespace FastReport.Data
         {
           Column c = column.Columns[i];
           // delete columns with empty descriptors, except the "Value" columns
-          if (c.PropDescriptor == null && c.PropName != "Value")
+          if (c.PropDescriptor == null && !c.Calculated && c.PropName != "Value")
           {
             column.Columns.RemoveAt(i);
             i--;


### PR DESCRIPTION
I've added support for Calculated parameters for BusinessObjectDataSource.
I didn't touch the report designer, so calculated parameter can only be added via .frx file.
`<Column Name="VehiclesMethod" DataType="System.String" Calculated="true" Expression="Test()"/>`