### PR TITLE
Fixed alpha channel not being respected in colors during HTMLExport

### DIFF
--- a/FastReport.Base/Export/ExportUtils.cs
+++ b/FastReport.Base/Export/ExportUtils.cs
@@ -268,17 +268,12 @@ namespace FastReport.Export
 
         internal static string HTMLColor(Color color)
         {
-            return ColorTranslator.ToHtml(color);
-        }
-
-        internal static string HTMLColorCode(Color color)
-        {
-            return String.Join(String.Empty, new String[] {
-                "#",
-                color.R.ToString("X2"),
-                color.G.ToString("X2"),
-                color.B.ToString("X2")
-            });
+            if (color.A < 255)
+            {
+                string alphaValue = (color.A / 255.0).ToString("0.00", INVARIANT_CULTURE);
+                return $"rgba({color.R}, {color.G}, {color.B}, {alphaValue})";
+            }
+            return $"rgb({color.R}, {color.G}, {color.B})";
         }
 
         internal static string ByteToHex(byte Byte)


### PR DESCRIPTION
Fix: Include alpha channel in color representation for HTMLExport

Description:

- Modified the HTMLColorCode function in the ExportUtils class to include the alpha channel in color representation for HTMLExport in FastReport.
- The previous implementation using ColorTranslator.ToHtml() did not account for the alpha channel, resulting in incorrect color representation in exported HTML.
- The modified function now properly handles the alpha channel, ensuring accurate color representation in the exported HTML.
- Tested the modification locally and verified its effectiveness.

https://github.com/FastReports/FastReport/issues/667