### PR TITLE
Fixes a problem with Empty arrays using JSON datasources

### DIFF
--- a/FastReport.Base/Data/JsonConnection/JsonTableDataSource.cs
+++ b/FastReport.Base/Data/JsonConnection/JsonTableDataSource.cs
@@ -189,6 +189,10 @@ namespace FastReport.Data.JsonConnection
                 {
                     if (!String.IsNullOrEmpty(column.PropName))
                     {
+                        if((parentColumn as JsonTableDataSource).RowCount == 0) {
+                            return null;
+                        }
+
                         var obj = (parentColumn as JsonTableDataSource).Json[(parentColumn as JsonTableDataSource).CurrentIndex];
 
                         return (obj as JsonBase)[column.PropName];


### PR DESCRIPTION
Previously if you had a an array of complex objects including arrays inside them, you would get a NullReferenceException if the incoming data could have any of those arrays be empty. With the added check, the program will correctly understand the lack of value in that property path